### PR TITLE
feat: #38 Add cart_items table schema and cart types

### DIFF
--- a/musinsa-coding/backend/db/schema.sql
+++ b/musinsa-coding/backend/db/schema.sql
@@ -44,3 +44,17 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
 
 CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON refresh_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
+
+CREATE TABLE IF NOT EXISTS cart_items (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id         INTEGER       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  product_id      INTEGER       NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  quantity        INTEGER       NOT NULL DEFAULT 1,
+  selected_option VARCHAR(100)  NOT NULL,
+  created_at      TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at      TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cart_items_user_product_option
+  ON cart_items(user_id, product_id, selected_option);
+CREATE INDEX IF NOT EXISTS idx_cart_items_user_id ON cart_items(user_id);

--- a/musinsa-coding/backend/src/types/cart.ts
+++ b/musinsa-coding/backend/src/types/cart.ts
@@ -1,0 +1,29 @@
+export interface CartItemRow {
+  id: number;
+  user_id: number;
+  product_id: number;
+  quantity: number;
+  selected_option: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CartItemWithProduct extends CartItemRow {
+  brand: string;
+  name: string;
+  price: number;
+  sale_price: number | null;
+  thumbnail_url: string | null;
+}
+
+export interface CartItemResponse {
+  id: number;
+  productId: number;
+  brand: string;
+  name: string;
+  price: number;
+  salePrice: number | null;
+  thumbnailUrl: string | null;
+  quantity: number;
+  selectedOption: string;
+}


### PR DESCRIPTION
## Summary\n\n- `db/schema.sql`에 `cart_items` 테이블 DDL, 유니크 인덱스, 일반 인덱스 추가\n- `src/types/cart.ts` 생성: `CartItemRow`, `CartItemWithProduct`, `CartItemResponse` 타입 정의\n\nClose #38