### PR TITLE
feat: #41 Add cart API endpoints (validator, controller, routes)

### DIFF
--- a/musinsa-coding/backend/src/controllers/cartController.ts
+++ b/musinsa-coding/backend/src/controllers/cartController.ts
@@ -1,0 +1,104 @@
+import type { Request, Response } from "express";
+import {
+  addItemSchema,
+  updateQuantitySchema,
+  removeItemsSchema,
+} from "../validators/cartValidator.js";
+import * as cartService from "../services/cartService.js";
+
+export function getCart(req: Request, res: Response): void {
+  const items = cartService.getCart(req.userId!);
+  res.json({ items });
+}
+
+export async function addItem(req: Request, res: Response): Promise<void> {
+  const parsed = addItemSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.issues });
+    return;
+  }
+
+  try {
+    const { productId, quantity, selectedOption } = parsed.data;
+    const item = cartService.addItem(
+      req.userId!,
+      productId,
+      quantity,
+      selectedOption,
+    );
+    res.status(201).json({ item });
+  } catch (err) {
+    if (err instanceof cartService.CartNotFoundError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+}
+
+export function updateQuantity(req: Request, res: Response): void {
+  const itemId = Number(req.params.itemId);
+  if (!Number.isInteger(itemId) || itemId <= 0) {
+    res.status(400).json({ error: "유효하지 않은 아이템 ID입니다" });
+    return;
+  }
+
+  const parsed = updateQuantitySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.issues });
+    return;
+  }
+
+  try {
+    const item = cartService.updateQuantity(
+      req.userId!,
+      itemId,
+      parsed.data.quantity,
+    );
+    res.json({ item });
+  } catch (err) {
+    if (err instanceof cartService.CartNotFoundError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
+    if (err instanceof cartService.CartForbiddenError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+}
+
+export function removeItem(req: Request, res: Response): void {
+  const itemId = Number(req.params.itemId);
+  if (!Number.isInteger(itemId) || itemId <= 0) {
+    res.status(400).json({ error: "유효하지 않은 아이템 ID입니다" });
+    return;
+  }
+
+  try {
+    cartService.removeItem(req.userId!, itemId);
+    res.status(204).end();
+  } catch (err) {
+    if (err instanceof cartService.CartNotFoundError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
+    if (err instanceof cartService.CartForbiddenError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+}
+
+export function removeItems(req: Request, res: Response): void {
+  const parsed = removeItemsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.issues });
+    return;
+  }
+
+  const deleted = cartService.removeItems(req.userId!, parsed.data.itemIds);
+  res.json({ deleted });
+}

--- a/musinsa-coding/backend/src/routes/cartRoutes.ts
+++ b/musinsa-coding/backend/src/routes/cartRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import * as cartController from "../controllers/cartController.js";
+import { authenticate } from "../middleware/authenticate.js";
+
+const router = Router();
+
+router.use(authenticate);
+
+router.get("/", cartController.getCart);
+router.post("/items", cartController.addItem);
+router.patch("/items/:itemId", cartController.updateQuantity);
+router.delete("/items/:itemId", cartController.removeItem);
+router.delete("/items", cartController.removeItems);
+
+export default router;

--- a/musinsa-coding/backend/src/routes/index.ts
+++ b/musinsa-coding/backend/src/routes/index.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import * as healthController from "../controllers/healthController.js";
 import authRoutes from "./authRoutes.js";
+import cartRoutes from "./cartRoutes.js";
 
 const router = Router();
 router.get("/health", healthController.get);
 router.use("/auth", authRoutes);
+router.use("/cart", cartRoutes);
 
 export default router;

--- a/musinsa-coding/backend/src/validators/cartValidator.ts
+++ b/musinsa-coding/backend/src/validators/cartValidator.ts
@@ -1,0 +1,35 @@
+import { z } from "zod/v4";
+
+export const addItemSchema = z.object({
+  productId: z
+    .number()
+    .int("상품 ID는 정수여야 합니다")
+    .positive("상품 ID는 양수여야 합니다"),
+  quantity: z
+    .number()
+    .int("수량은 정수여야 합니다")
+    .min(1, "수량은 1 이상이어야 합니다")
+    .max(99, "수량은 99 이하여야 합니다"),
+  selectedOption: z
+    .string()
+    .min(1, "옵션을 선택해주세요")
+    .max(100, "옵션은 100자 이하여야 합니다"),
+});
+
+export const updateQuantitySchema = z.object({
+  quantity: z
+    .number()
+    .int("수량은 정수여야 합니다")
+    .min(1, "수량은 1 이상이어야 합니다")
+    .max(99, "수량은 99 이하여야 합니다"),
+});
+
+export const removeItemsSchema = z.object({
+  itemIds: z
+    .array(z.number().int().positive())
+    .min(1, "삭제할 아이템을 선택해주세요"),
+});
+
+export type AddItemInput = z.infer<typeof addItemSchema>;
+export type UpdateQuantityInput = z.infer<typeof updateQuantitySchema>;
+export type RemoveItemsInput = z.infer<typeof removeItemsSchema>;


### PR DESCRIPTION
## Summary\n\n- `src/validators/cartValidator.ts`: Zod v4 스키마 3개 (addItem, updateQuantity, removeItems)\n- `src/controllers/cartController.ts`: 5개 핸들러 (getCart, addItem, updateQuantity, removeItem, removeItems)\n- `src/routes/cartRoutes.ts`: 라우트 정의 + authenticate 미들웨어 적용\n- `src/routes/index.ts`: `/api/cart` 라우트 등록\n\n### API 엔드포인트\n- GET `/api/cart` - 장바구니 조회\n- POST `/api/cart/items` - 상품 추가\n- PATCH `/api/cart/items/:itemId` - 수량 변경\n- DELETE `/api/cart/items/:itemId` - 개별 삭제\n- DELETE `/api/cart/items` - 선택 삭제\n\nClose #41