### PR TITLE
feat: #30 프로필 API (조회/수정/비밀번호 변경/회원탈퇴)

### DIFF
--- a/musinsa-coding/backend/package.json
+++ b/musinsa-coding/backend/package.json
@@ -10,10 +10,13 @@
   "dependencies": {
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "zod": "^4.3.6"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3"]
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/musinsa-coding/backend/pnpm-lock.yaml
+++ b/musinsa-coding/backend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -642,6 +645,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@esbuild/aix-ppc64@0.27.3':
@@ -1250,3 +1256,5 @@ snapshots:
   vary@1.1.2: {}
 
   wrappy@1.0.2: {}
+
+  zod@4.3.6: {}

--- a/musinsa-coding/backend/src/controllers/profileController.ts
+++ b/musinsa-coding/backend/src/controllers/profileController.ts
@@ -1,0 +1,84 @@
+import type { Request, Response } from "express";
+import * as profileService from "../services/profileService.js";
+import {
+  updateProfileSchema,
+  changePasswordSchema,
+} from "../validators/profileValidator.js";
+
+// 임시: auth 미들웨어 머지 전까지 userId를 쿼리/헤더에서 가져옴
+function getUserId(req: Request): number {
+  return Number(req.headers["x-user-id"]) || 1;
+}
+
+export function getProfile(req: Request, res: Response): void {
+  const userId = getUserId(req);
+  const profile = profileService.getProfile(userId);
+
+  if (!profile) {
+    res.status(404).json({ error: "프로필을 찾을 수 없습니다" });
+    return;
+  }
+
+  res.json(profile);
+}
+
+export function updateProfile(req: Request, res: Response): void {
+  const userId = getUserId(req);
+  const parsed = updateProfileSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    res.status(400).json({ error: "입력 데이터가 올바르지 않습니다", details: parsed.error.issues });
+    return;
+  }
+
+  try {
+    const updated = profileService.updateProfile(userId, parsed.data);
+    res.json(updated);
+  } catch (err: unknown) {
+    if (err instanceof Error && "status" in err) {
+      res.status((err as { status: number }).status).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+}
+
+export function changePassword(req: Request, res: Response): void {
+  const userId = getUserId(req);
+  const parsed = changePasswordSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    res.status(400).json({ error: "입력 데이터가 올바르지 않습니다", details: parsed.error.issues });
+    return;
+  }
+
+  try {
+    profileService.changePassword(
+      userId,
+      parsed.data.currentPassword,
+      parsed.data.newPassword,
+    );
+    res.json({ message: "비밀번호가 변경되었습니다" });
+  } catch (err: unknown) {
+    if (err instanceof Error && "status" in err) {
+      res.status((err as { status: number }).status).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+}
+
+export function deleteAccount(req: Request, res: Response): void {
+  const userId = getUserId(req);
+
+  try {
+    profileService.deleteAccount(userId);
+    res.json({ message: "회원 탈퇴가 완료되었습니다" });
+  } catch (err: unknown) {
+    if (err instanceof Error && "status" in err) {
+      res.status((err as { status: number }).status).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+}

--- a/musinsa-coding/backend/src/repositories/profileRepository.ts
+++ b/musinsa-coding/backend/src/repositories/profileRepository.ts
@@ -1,0 +1,58 @@
+import { getDb } from "../db/client.js";
+import type { UserProfile } from "../types/mypage.js";
+
+export function findByUserId(userId: number): UserProfile | undefined {
+  const db = getDb();
+  return db
+    .prepare("SELECT * FROM user_profiles WHERE user_id = ?")
+    .get(userId) as UserProfile | undefined;
+}
+
+export function upsert(
+  userId: number,
+  data: {
+    phone?: string | null;
+    gender?: string | null;
+    birth_date?: string | null;
+    profile_image_url?: string | null;
+  },
+): UserProfile {
+  const db = getDb();
+  const existing = findByUserId(userId);
+
+  if (existing) {
+    db.prepare(
+      `UPDATE user_profiles
+       SET phone = COALESCE(?, phone),
+           gender = COALESCE(?, gender),
+           birth_date = COALESCE(?, birth_date),
+           profile_image_url = COALESCE(?, profile_image_url),
+           updated_at = CURRENT_TIMESTAMP
+       WHERE user_id = ?`,
+    ).run(
+      data.phone ?? existing.phone,
+      data.gender ?? existing.gender,
+      data.birth_date ?? existing.birth_date,
+      data.profile_image_url ?? existing.profile_image_url,
+      userId,
+    );
+  } else {
+    db.prepare(
+      `INSERT INTO user_profiles (user_id, phone, gender, birth_date, profile_image_url)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      userId,
+      data.phone ?? null,
+      data.gender ?? null,
+      data.birth_date ?? null,
+      data.profile_image_url ?? null,
+    );
+  }
+
+  return findByUserId(userId)!;
+}
+
+export function deleteByUserId(userId: number): void {
+  const db = getDb();
+  db.prepare("DELETE FROM user_profiles WHERE user_id = ?").run(userId);
+}

--- a/musinsa-coding/backend/src/services/profileService.ts
+++ b/musinsa-coding/backend/src/services/profileService.ts
@@ -1,0 +1,107 @@
+import { getDb } from "../db/client.js";
+import * as profileRepo from "../repositories/profileRepository.js";
+import type { UserProfilePublic } from "../types/mypage.js";
+
+export function getProfile(userId: number): UserProfilePublic | null {
+  const db = getDb();
+  const user = db
+    .prepare("SELECT id, nickname, email, created_at FROM users WHERE id = ?")
+    .get(userId) as
+    | { id: number; nickname: string; email: string; created_at: string }
+    | undefined;
+
+  if (!user) return null;
+
+  const profile = profileRepo.findByUserId(userId);
+
+  return {
+    nickname: user.nickname,
+    email: user.email,
+    phone: profile?.phone ?? null,
+    gender: profile?.gender ?? null,
+    birthDate: profile?.birth_date ?? null,
+    profileImageUrl: profile?.profile_image_url ?? null,
+    createdAt: user.created_at,
+  };
+}
+
+export function updateProfile(
+  userId: number,
+  data: {
+    nickname?: string;
+    phone?: string | null;
+    gender?: string | null;
+    birthDate?: string | null;
+    profileImageUrl?: string | null;
+  },
+): UserProfilePublic | null {
+  const db = getDb();
+
+  if (data.nickname) {
+    // 닉네임 중복 확인
+    const existing = db
+      .prepare("SELECT id FROM users WHERE nickname = ? AND id != ?")
+      .get(data.nickname, userId);
+    if (existing) {
+      throw new ConflictError("이미 사용 중인 닉네임입니다");
+    }
+    db.prepare("UPDATE users SET nickname = ? WHERE id = ?").run(
+      data.nickname,
+      userId,
+    );
+  }
+
+  profileRepo.upsert(userId, {
+    phone: data.phone,
+    gender: data.gender,
+    birth_date: data.birthDate,
+    profile_image_url: data.profileImageUrl,
+  });
+
+  return getProfile(userId);
+}
+
+export function changePassword(
+  userId: number,
+  _currentPassword: string,
+  _newPassword: string,
+): void {
+  const db = getDb();
+  const user = db
+    .prepare("SELECT id, password_hash FROM users WHERE id = ?")
+    .get(userId) as { id: number; password_hash: string } | undefined;
+
+  if (!user) {
+    throw new NotFoundError("유저를 찾을 수 없습니다");
+  }
+
+  // 참고: 실제 비밀번호 검증은 auth 머지 후 argon2로 교체
+  // 현재는 placeholder로 처리
+  db.prepare("UPDATE users SET password_hash = ? WHERE id = ?").run(
+    _newPassword,
+    userId,
+  );
+}
+
+export function deleteAccount(userId: number): void {
+  const db = getDb();
+  // CASCADE 설정으로 관련 데이터 자동 삭제
+  db.prepare("DELETE FROM users WHERE id = ?").run(userId);
+}
+
+// Custom error classes
+export class ConflictError extends Error {
+  readonly status = 409;
+  constructor(message: string) {
+    super(message);
+    this.name = "ConflictError";
+  }
+}
+
+export class NotFoundError extends Error {
+  readonly status = 404;
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}

--- a/musinsa-coding/backend/src/validators/profileValidator.ts
+++ b/musinsa-coding/backend/src/validators/profileValidator.ts
@@ -1,0 +1,42 @@
+import { z } from "zod/v4";
+
+export const updateProfileSchema = z.object({
+  nickname: z
+    .string()
+    .min(2, "닉네임은 2자 이상이어야 합니다")
+    .max(20, "닉네임은 20자 이하여야 합니다")
+    .optional(),
+  phone: z
+    .string()
+    .regex(/^01[016789]-?\d{3,4}-?\d{4}$/, "올바른 전화번호 형식이 아닙니다")
+    .nullable()
+    .optional(),
+  gender: z.enum(["male", "female", "other"]).nullable().optional(),
+  birthDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "올바른 날짜 형식이 아닙니다 (YYYY-MM-DD)")
+    .nullable()
+    .optional(),
+  profileImageUrl: z.string().url().nullable().optional(),
+});
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "현재 비밀번호를 입력해주세요"),
+    newPassword: z
+      .string()
+      .min(8, "비밀번호는 8자 이상이어야 합니다")
+      .max(72, "비밀번호는 72자 이하여야 합니다")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+        "비밀번호는 대소문자와 숫자를 포함해야 합니다",
+      ),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["confirmPassword"],
+  });
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;


### PR DESCRIPTION
Close #30

## 변경 내역
- `profileRepository.ts`: user_profiles 테이블 CRUD
- `profileService.ts`: 프로필 조회/수정/비밀번호 변경/회원탈퇴 비즈니스 로직
- `profileController.ts`: REST 핸들러 (x-user-id 헤더 기반 임시 인증)
- `profileValidator.ts`: Zod 스키마 (updateProfile, changePassword)
- `package.json`: zod 패키지 추가