### PR TITLE
feat: #33 프로필 수정 + 계정 설정 UI

### DIFF
--- a/musinsa-coding/frontend/src/app/my/profile/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/profile/page.css.ts
@@ -1,0 +1,150 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const profilePage = style({
+  backgroundColor: vars.color.white,
+  minHeight: "100vh",
+});
+
+export const avatarSection = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  padding: `${vars.space.xl} ${vars.space.md}`,
+  gap: vars.space.sm,
+});
+
+export const avatarWrapper = style({
+  position: "relative",
+  width: "80px",
+  height: "80px",
+});
+
+export const avatarCircle = style({
+  width: "80px",
+  height: "80px",
+  borderRadius: vars.radius.full,
+  backgroundColor: vars.color.gray200,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  overflow: "hidden",
+});
+
+export const avatarIconLarge = style({
+  width: "36px",
+  height: "36px",
+  color: vars.color.gray500,
+});
+
+export const cameraButton = style({
+  position: "absolute",
+  bottom: 0,
+  right: 0,
+  width: "28px",
+  height: "28px",
+  borderRadius: vars.radius.full,
+  backgroundColor: vars.color.white,
+  border: `1px solid ${vars.color.border}`,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  cursor: "pointer",
+});
+
+export const cameraIcon = style({
+  width: "14px",
+  height: "14px",
+  color: vars.color.gray600,
+});
+
+export const formSection = style({
+  padding: `0 ${vars.space.md} ${vars.space.lg}`,
+});
+
+export const fieldGroup = style({
+  marginBottom: vars.space.lg,
+});
+
+export const fieldLabel = style({
+  display: "block",
+  fontSize: "13px",
+  fontWeight: 600,
+  color: vars.color.textSecondary,
+  marginBottom: vars.space.sm,
+});
+
+export const fieldInput = style({
+  width: "100%",
+  padding: `12px ${vars.space.md}`,
+  fontSize: "15px",
+  color: vars.color.textPrimary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.white,
+  outline: "none",
+  transition: "border-color 0.15s",
+  ":focus": {
+    borderColor: vars.color.black,
+  },
+  "::placeholder": {
+    color: vars.color.textTertiary,
+  },
+});
+
+export const fieldInputDisabled = style({
+  width: "100%",
+  padding: `12px ${vars.space.md}`,
+  fontSize: "15px",
+  color: vars.color.textTertiary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.gray100,
+});
+
+export const genderRow = style({
+  display: "flex",
+  gap: vars.space.sm,
+});
+
+export const genderButton = style({
+  flex: 1,
+  padding: `10px 0`,
+  fontSize: "14px",
+  textAlign: "center",
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.white,
+  color: vars.color.textSecondary,
+  cursor: "pointer",
+  transition: "all 0.15s",
+});
+
+export const genderButtonActive = style({
+  flex: 1,
+  padding: `10px 0`,
+  fontSize: "14px",
+  textAlign: "center",
+  border: `1px solid ${vars.color.black}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.black,
+  color: vars.color.white,
+  cursor: "pointer",
+  fontWeight: 600,
+});
+
+export const submitButton = style({
+  width: "100%",
+  padding: "14px 0",
+  fontSize: "16px",
+  fontWeight: 700,
+  color: vars.color.white,
+  backgroundColor: vars.color.black,
+  borderRadius: vars.radius.md,
+  cursor: "pointer",
+  transition: "opacity 0.15s",
+  marginTop: vars.space.md,
+  ":hover": {
+    opacity: 0.85,
+  },
+});

--- a/musinsa-coding/frontend/src/app/my/profile/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/profile/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { mockUserProfile } from "@/data/mock/user";
+import {
+  profilePage,
+  avatarSection,
+  avatarWrapper,
+  avatarCircle,
+  avatarIconLarge,
+  cameraButton,
+  cameraIcon,
+  formSection,
+  fieldGroup,
+  fieldLabel,
+  fieldInput,
+  fieldInputDisabled,
+  genderRow,
+  genderButton,
+  genderButtonActive,
+  submitButton,
+} from "./page.css";
+
+export default function ProfileEditPage() {
+  const [nickname, setNickname] = useState(mockUserProfile.nickname);
+  const [phone, setPhone] = useState(mockUserProfile.phone ?? "");
+  const [gender, setGender] = useState(mockUserProfile.gender ?? "");
+  const [birthDate, setBirthDate] = useState(mockUserProfile.birthDate ?? "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: API 연동
+    alert("프로필이 저장되었습니다");
+  };
+
+  return (
+    <div className={profilePage}>
+      <div className={avatarSection}>
+        <div className={avatarWrapper}>
+          <div className={avatarCircle}>
+            <svg
+              className={avatarIconLarge}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.8}
+            >
+              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+              <circle cx="12" cy="7" r="4" />
+            </svg>
+          </div>
+          <button className={cameraButton} aria-label="프로필 사진 변경">
+            <svg
+              className={cameraIcon}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+              <circle cx="12" cy="13" r="4" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <form className={formSection} onSubmit={handleSubmit}>
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>이메일</label>
+          <input
+            className={fieldInputDisabled}
+            type="email"
+            value={mockUserProfile.email}
+            disabled
+          />
+        </div>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>닉네임</label>
+          <input
+            className={fieldInput}
+            type="text"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder="닉네임을 입력해주세요"
+            maxLength={20}
+          />
+        </div>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>전화번호</label>
+          <input
+            className={fieldInput}
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="010-0000-0000"
+          />
+        </div>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>성별</label>
+          <div className={genderRow}>
+            {(["male", "female", "other"] as const).map((g) => (
+              <button
+                key={g}
+                type="button"
+                className={gender === g ? genderButtonActive : genderButton}
+                onClick={() => setGender(g)}
+              >
+                {g === "male" ? "남성" : g === "female" ? "여성" : "기타"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>생년월일</label>
+          <input
+            className={fieldInput}
+            type="date"
+            value={birthDate}
+            onChange={(e) => setBirthDate(e.target.value)}
+          />
+        </div>
+
+        <button type="submit" className={submitButton}>
+          저장하기
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/app/my/settings/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/settings/page.css.ts
@@ -1,0 +1,161 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const settingsPage = style({
+  backgroundColor: vars.color.gray100,
+  minHeight: "100vh",
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space.sm,
+});
+
+export const settingsSection = style({
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.lg} ${vars.space.md}`,
+});
+
+export const sectionTitle = style({
+  fontSize: "15px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space.md,
+});
+
+export const fieldGroup = style({
+  marginBottom: vars.space.md,
+});
+
+export const fieldLabel = style({
+  display: "block",
+  fontSize: "13px",
+  fontWeight: 600,
+  color: vars.color.textSecondary,
+  marginBottom: vars.space.sm,
+});
+
+export const fieldInput = style({
+  width: "100%",
+  padding: `12px ${vars.space.md}`,
+  fontSize: "15px",
+  color: vars.color.textPrimary,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.white,
+  outline: "none",
+  transition: "border-color 0.15s",
+  ":focus": {
+    borderColor: vars.color.black,
+  },
+});
+
+export const saveButton = style({
+  width: "100%",
+  padding: "14px 0",
+  fontSize: "16px",
+  fontWeight: 700,
+  color: vars.color.white,
+  backgroundColor: vars.color.black,
+  borderRadius: vars.radius.md,
+  cursor: "pointer",
+  transition: "opacity 0.15s",
+  marginTop: vars.space.sm,
+  ":hover": {
+    opacity: 0.85,
+  },
+});
+
+export const dangerSection = style({
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.lg} ${vars.space.md}`,
+});
+
+export const dangerTitle = style({
+  fontSize: "15px",
+  fontWeight: 700,
+  color: "#D32F2F",
+  marginBottom: vars.space.sm,
+});
+
+export const dangerDescription = style({
+  fontSize: "13px",
+  color: vars.color.textSecondary,
+  lineHeight: 1.5,
+  marginBottom: vars.space.md,
+});
+
+export const dangerButton = style({
+  width: "100%",
+  padding: "14px 0",
+  fontSize: "15px",
+  fontWeight: 600,
+  color: "#D32F2F",
+  backgroundColor: vars.color.white,
+  border: "1px solid #D32F2F",
+  borderRadius: vars.radius.md,
+  cursor: "pointer",
+  transition: "all 0.15s",
+  ":hover": {
+    backgroundColor: "#FFF5F5",
+  },
+});
+
+export const modalOverlay = style({
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.5)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 200,
+  padding: vars.space.md,
+});
+
+export const modal = style({
+  width: "100%",
+  maxWidth: "340px",
+  backgroundColor: vars.color.white,
+  borderRadius: vars.radius.lg,
+  padding: vars.space.lg,
+  textAlign: "center",
+});
+
+export const modalTitle = style({
+  fontSize: "17px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space.sm,
+});
+
+export const modalDescription = style({
+  fontSize: "14px",
+  color: vars.color.textSecondary,
+  lineHeight: 1.5,
+  marginBottom: vars.space.lg,
+});
+
+export const modalActions = style({
+  display: "flex",
+  gap: vars.space.sm,
+});
+
+export const modalCancel = style({
+  flex: 1,
+  padding: "12px 0",
+  fontSize: "15px",
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  backgroundColor: vars.color.gray100,
+  borderRadius: vars.radius.md,
+  cursor: "pointer",
+});
+
+export const modalConfirm = style({
+  flex: 1,
+  padding: "12px 0",
+  fontSize: "15px",
+  fontWeight: 600,
+  color: vars.color.white,
+  backgroundColor: "#D32F2F",
+  borderRadius: vars.radius.md,
+  cursor: "pointer",
+});

--- a/musinsa-coding/frontend/src/app/my/settings/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/settings/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import {
+  settingsPage,
+  settingsSection,
+  sectionTitle,
+  fieldGroup,
+  fieldLabel,
+  fieldInput,
+  saveButton,
+  dangerSection,
+  dangerTitle,
+  dangerDescription,
+  dangerButton,
+  modalOverlay,
+  modal,
+  modalTitle,
+  modalDescription,
+  modalActions,
+  modalCancel,
+  modalConfirm,
+} from "./page.css";
+
+export default function SettingsPage() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showModal, setShowModal] = useState(false);
+
+  const handleChangePassword = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      alert("새 비밀번호가 일치하지 않습니다");
+      return;
+    }
+    if (newPassword.length < 8) {
+      alert("비밀번호는 8자 이상이어야 합니다");
+      return;
+    }
+    // TODO: API 연동
+    alert("비밀번호가 변경되었습니다");
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+  };
+
+  const handleDeleteAccount = () => {
+    // TODO: API 연동
+    alert("회원 탈퇴가 완료되었습니다");
+    setShowModal(false);
+  };
+
+  return (
+    <div className={settingsPage}>
+      <form className={settingsSection} onSubmit={handleChangePassword}>
+        <h2 className={sectionTitle}>비밀번호 변경</h2>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>현재 비밀번호</label>
+          <input
+            className={fieldInput}
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            placeholder="현재 비밀번호를 입력해주세요"
+            required
+          />
+        </div>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>새 비밀번호</label>
+          <input
+            className={fieldInput}
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="새 비밀번호 (8자 이상, 대소문자+숫자)"
+            required
+            minLength={8}
+          />
+        </div>
+
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>새 비밀번호 확인</label>
+          <input
+            className={fieldInput}
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="새 비밀번호를 다시 입력해주세요"
+            required
+          />
+        </div>
+
+        <button type="submit" className={saveButton}>
+          비밀번호 변경
+        </button>
+      </form>
+
+      <div className={dangerSection}>
+        <h2 className={dangerTitle}>회원 탈퇴</h2>
+        <p className={dangerDescription}>
+          회원 탈퇴 시 모든 데이터(주문 내역, 리뷰, 쿠폰, 포인트 등)가
+          영구적으로 삭제되며 복구할 수 없습니다.
+        </p>
+        <button
+          type="button"
+          className={dangerButton}
+          onClick={() => setShowModal(true)}
+        >
+          회원 탈퇴하기
+        </button>
+      </div>
+
+      {showModal && (
+        <div
+          className={modalOverlay}
+          onClick={() => setShowModal(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="회원 탈퇴 확인"
+        >
+          <div className={modal} onClick={(e) => e.stopPropagation()}>
+            <h3 className={modalTitle}>정말 탈퇴하시겠습니까?</h3>
+            <p className={modalDescription}>
+              탈퇴 후에는 계정을 복구할 수 없습니다.
+              <br />
+              모든 데이터가 영구 삭제됩니다.
+            </p>
+            <div className={modalActions}>
+              <button
+                className={modalCancel}
+                onClick={() => setShowModal(false)}
+              >
+                취소
+              </button>
+              <button className={modalConfirm} onClick={handleDeleteAccount}>
+                탈퇴하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Close #33

## 변경 내역
- **프로필 수정 페이지** (`/my/profile`): 닉네임, 전화번호, 성별, 생년월일, 프로필 이미지 업로드 폼
- **계정 설정 페이지** (`/my/settings`): 비밀번호 변경 폼 (현재/신규/확인) + 회원탈퇴 확인 모달
- Mock 데이터 기반 폼 초기값 + Vanilla Extract 스타일링