### PR TITLE
feat: #34 주문 내역 + 리뷰 관리 UI

### DIFF
--- a/musinsa-coding/frontend/src/app/my/orders/[id]/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/orders/[id]/page.css.ts
@@ -1,0 +1,116 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const detailPage = style({
+  minHeight: "100vh",
+  backgroundColor: vars.color.gray100,
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space.sm,
+});
+
+export const section = style({
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.lg} ${vars.space.md}`,
+});
+
+export const sectionTitle = style({
+  fontSize: "15px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space.md,
+});
+
+export const statusRow = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  marginBottom: vars.space.md,
+});
+
+export const statusBadgeLarge = style({
+  fontSize: "14px",
+  fontWeight: 700,
+  padding: "6px 12px",
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.black,
+  color: vars.color.white,
+});
+
+export const orderMeta = style({
+  fontSize: "13px",
+  color: vars.color.textSecondary,
+});
+
+export const itemCard = style({
+  display: "flex",
+  gap: vars.space.md,
+  padding: `${vars.space.md} 0`,
+  borderBottom: `1px solid ${vars.color.gray100}`,
+  alignItems: "center",
+  selectors: {
+    "&:last-child": {
+      borderBottom: "none",
+    },
+  },
+});
+
+export const itemThumb = style({
+  width: "72px",
+  height: "72px",
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.gray200,
+  objectFit: "cover",
+  flexShrink: 0,
+});
+
+export const itemDetail = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const itemBrand = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+  marginBottom: "2px",
+});
+
+export const itemName = style({
+  fontSize: "14px",
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+});
+
+export const itemMeta = style({
+  fontSize: "13px",
+  color: vars.color.textSecondary,
+  marginTop: "4px",
+});
+
+export const itemPriceBold = style({
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+});
+
+export const summaryTable = style({
+  width: "100%",
+});
+
+export const summaryRow = style({
+  display: "flex",
+  justifyContent: "space-between",
+  padding: `${vars.space.sm} 0`,
+  fontSize: "14px",
+  color: vars.color.textSecondary,
+});
+
+export const summaryTotal = style({
+  display: "flex",
+  justifyContent: "space-between",
+  padding: `${vars.space.md} 0`,
+  fontSize: "16px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  borderTop: `1px solid ${vars.color.border}`,
+  marginTop: vars.space.sm,
+});

--- a/musinsa-coding/frontend/src/app/my/orders/[id]/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/orders/[id]/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { use } from "react";
+import { mockOrders } from "@/data/mock/orders";
+import type { OrderStatus } from "@/types";
+import {
+  detailPage,
+  section,
+  sectionTitle,
+  statusRow,
+  statusBadgeLarge,
+  orderMeta,
+  itemCard,
+  itemThumb,
+  itemDetail,
+  itemBrand,
+  itemName,
+  itemMeta,
+  itemPriceBold,
+  summaryRow,
+  summaryTotal,
+} from "./page.css";
+
+const STATUS_LABELS: Record<OrderStatus, string> = {
+  pending: "입금대기",
+  paid: "결제완료",
+  shipping: "배송중",
+  delivered: "배송완료",
+  confirmed: "구매확정",
+  cancelled: "주문취소",
+};
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function OrderDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const order = mockOrders.find((o) => o.id === Number(id));
+
+  if (!order) {
+    return (
+      <div className={detailPage}>
+        <div className={section}>
+          <p>주문을 찾을 수 없습니다.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const productTotal = order.items.reduce(
+    (sum, item) => sum + (item.salePrice ?? item.price) * item.quantity,
+    0,
+  );
+
+  return (
+    <div className={detailPage}>
+      {/* 주문 상태 */}
+      <div className={section}>
+        <div className={statusRow}>
+          <span className={statusBadgeLarge}>
+            {STATUS_LABELS[order.status]}
+          </span>
+          <span className={orderMeta}>
+            {formatDate(order.orderedAt)} | {order.orderNumber}
+          </span>
+        </div>
+      </div>
+
+      {/* 주문 상품 */}
+      <div className={section}>
+        <h2 className={sectionTitle}>주문 상품</h2>
+        {order.items.map((item) => (
+          <div key={item.id} className={itemCard}>
+            <img
+              className={itemThumb}
+              src={item.productThumbnail}
+              alt={item.productName}
+            />
+            <div className={itemDetail}>
+              <div className={itemBrand}>{item.productBrand}</div>
+              <div className={itemName}>{item.productName}</div>
+              <div className={itemMeta}>
+                <span className={itemPriceBold}>
+                  {(item.salePrice ?? item.price).toLocaleString()}원
+                </span>
+                {" / "}
+                {item.quantity}개
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 결제 정보 */}
+      <div className={section}>
+        <h2 className={sectionTitle}>결제 정보</h2>
+        <div className={summaryRow}>
+          <span>상품 금액</span>
+          <span>{productTotal.toLocaleString()}원</span>
+        </div>
+        <div className={summaryRow}>
+          <span>배송비</span>
+          <span>
+            {order.shippingFee === 0
+              ? "무료"
+              : `${order.shippingFee.toLocaleString()}원`}
+          </span>
+        </div>
+        <div className={summaryTotal}>
+          <span>총 결제 금액</span>
+          <span>{order.totalAmount.toLocaleString()}원</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/app/my/orders/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/orders/page.css.ts
@@ -1,0 +1,47 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const ordersPage = style({
+  minHeight: "100vh",
+  backgroundColor: vars.color.gray100,
+});
+
+export const tabBar = style({
+  display: "flex",
+  backgroundColor: vars.color.white,
+  borderBottom: `1px solid ${vars.color.border}`,
+  overflowX: "auto",
+  scrollbarWidth: "none",
+  "::-webkit-scrollbar": {
+    display: "none",
+  },
+});
+
+export const tab = style({
+  padding: `12px ${vars.space.md}`,
+  fontSize: "14px",
+  color: vars.color.textTertiary,
+  whiteSpace: "nowrap",
+  cursor: "pointer",
+  borderBottom: "2px solid transparent",
+  transition: "all 0.15s",
+  flexShrink: 0,
+});
+
+export const tabActive = style({
+  padding: `12px ${vars.space.md}`,
+  fontSize: "14px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  whiteSpace: "nowrap",
+  cursor: "pointer",
+  borderBottom: `2px solid ${vars.color.black}`,
+  flexShrink: 0,
+});
+
+export const orderList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space.sm,
+  padding: vars.space.md,
+});

--- a/musinsa-coding/frontend/src/app/my/orders/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/orders/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import OrderCard from "@/components/my/OrderCard";
+import EmptyState from "@/components/my/EmptyState";
+import { mockOrders } from "@/data/mock/orders";
+import { ordersPage, tabBar, tab, tabActive, orderList } from "./page.css";
+
+const TABS = [
+  { key: "all", label: "전체" },
+  { key: "pending", label: "입금대기" },
+  { key: "paid", label: "결제완료" },
+  { key: "shipping", label: "배송중" },
+  { key: "delivered", label: "배송완료" },
+  { key: "confirmed", label: "구매확정" },
+];
+
+function OrdersContent() {
+  const searchParams = useSearchParams();
+  const initialStatus = searchParams.get("status") ?? "all";
+  const [activeTab, setActiveTab] = useState(initialStatus);
+
+  const filtered =
+    activeTab === "all"
+      ? mockOrders
+      : mockOrders.filter((o) => o.status === activeTab);
+
+  return (
+    <>
+      <div className={tabBar} role="tablist">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            className={activeTab === t.key ? tabActive : tab}
+            onClick={() => setActiveTab(t.key)}
+            role="tab"
+            aria-selected={activeTab === t.key}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className={orderList}>
+        {filtered.length > 0 ? (
+          filtered.map((order) => <OrderCard key={order.id} order={order} />)
+        ) : (
+          <EmptyState
+            icon="order"
+            title="주문 내역이 없습니다"
+            description="아직 주문한 상품이 없어요"
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+export default function OrdersPage() {
+  return (
+    <div className={ordersPage}>
+      <Suspense>
+        <OrdersContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/app/my/reviews/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/reviews/page.css.ts
@@ -1,0 +1,27 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const reviewsPage = style({
+  minHeight: "100vh",
+  backgroundColor: vars.color.gray100,
+});
+
+export const reviewCount = style({
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.md}`,
+  fontSize: "14px",
+  color: vars.color.textSecondary,
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const countBold = style({
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+});
+
+export const reviewList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space.sm,
+  padding: vars.space.md,
+});

--- a/musinsa-coding/frontend/src/app/my/reviews/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/reviews/page.tsx
@@ -1,0 +1,28 @@
+import ReviewCard from "@/components/my/ReviewCard";
+import EmptyState from "@/components/my/EmptyState";
+import { mockReviews } from "@/data/mock/reviews";
+import { reviewsPage, reviewCount, countBold, reviewList } from "./page.css";
+
+export default function ReviewsPage() {
+  return (
+    <div className={reviewsPage}>
+      <div className={reviewCount}>
+        작성한 리뷰 <span className={countBold}>{mockReviews.length}</span>건
+      </div>
+
+      <div className={reviewList}>
+        {mockReviews.length > 0 ? (
+          mockReviews.map((review) => (
+            <ReviewCard key={review.id} review={review} />
+          ))
+        ) : (
+          <EmptyState
+            icon="review"
+            title="작성한 리뷰가 없습니다"
+            description="구매한 상품의 리뷰를 작성해보세요"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/components/my/OrderCard.css.ts
+++ b/musinsa-coding/frontend/src/components/my/OrderCard.css.ts
@@ -1,0 +1,114 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const card = style({
+  backgroundColor: vars.color.white,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  overflow: "hidden",
+});
+
+export const cardHeader = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: `${vars.space.md}`,
+  borderBottom: `1px solid ${vars.color.gray100}`,
+});
+
+export const orderDate = style({
+  fontSize: "13px",
+  color: vars.color.textSecondary,
+});
+
+export const orderNumber = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+});
+
+export const statusBadge = style({
+  fontSize: "12px",
+  fontWeight: 600,
+  padding: "4px 8px",
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.gray100,
+  color: vars.color.textSecondary,
+});
+
+export const statusBadgeActive = style({
+  fontSize: "12px",
+  fontWeight: 600,
+  padding: "4px 8px",
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.black,
+  color: vars.color.white,
+});
+
+export const itemRow = style({
+  display: "flex",
+  gap: vars.space.md,
+  padding: vars.space.md,
+  alignItems: "center",
+  textDecoration: "none",
+  color: "inherit",
+  transition: "background-color 0.1s",
+  ":hover": {
+    backgroundColor: vars.color.gray100,
+  },
+});
+
+export const itemImage = style({
+  width: "64px",
+  height: "64px",
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.gray200,
+  objectFit: "cover",
+  flexShrink: 0,
+});
+
+export const itemInfo = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const itemBrand = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+  marginBottom: "2px",
+});
+
+export const itemName = style({
+  fontSize: "14px",
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+export const itemPrice = style({
+  fontSize: "14px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  marginTop: "4px",
+});
+
+export const itemQuantity = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+  marginLeft: "4px",
+  fontWeight: 400,
+});
+
+export const cardFooter = style({
+  display: "flex",
+  justifyContent: "flex-end",
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  borderTop: `1px solid ${vars.color.gray100}`,
+});
+
+export const totalAmount = style({
+  fontSize: "15px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+});

--- a/musinsa-coding/frontend/src/components/my/OrderCard.tsx
+++ b/musinsa-coding/frontend/src/components/my/OrderCard.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import type { Order, OrderStatus } from "@/types";
+import {
+  card,
+  cardHeader,
+  orderDate,
+  orderNumber,
+  statusBadge,
+  statusBadgeActive,
+  itemRow,
+  itemImage,
+  itemInfo,
+  itemBrand,
+  itemName,
+  itemPrice,
+  itemQuantity,
+  cardFooter,
+  totalAmount,
+} from "./OrderCard.css";
+
+interface Props {
+  order: Order;
+}
+
+const STATUS_LABELS: Record<OrderStatus, string> = {
+  pending: "입금대기",
+  paid: "결제완료",
+  shipping: "배송중",
+  delivered: "배송완료",
+  confirmed: "구매확정",
+  cancelled: "주문취소",
+};
+
+function isActiveStatus(status: OrderStatus): boolean {
+  return status === "shipping" || status === "paid";
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function OrderCard({ order }: Props) {
+  return (
+    <article className={card}>
+      <div className={cardHeader}>
+        <div>
+          <div className={orderDate}>{formatDate(order.orderedAt)}</div>
+          <div className={orderNumber}>{order.orderNumber}</div>
+        </div>
+        <span
+          className={
+            isActiveStatus(order.status) ? statusBadgeActive : statusBadge
+          }
+        >
+          {STATUS_LABELS[order.status]}
+        </span>
+      </div>
+
+      {order.items.map((item) => (
+        <Link
+          key={item.id}
+          href={`/my/orders/${order.id}`}
+          className={itemRow}
+        >
+          <img
+            className={itemImage}
+            src={item.productThumbnail}
+            alt={item.productName}
+          />
+          <div className={itemInfo}>
+            <div className={itemBrand}>{item.productBrand}</div>
+            <div className={itemName}>{item.productName}</div>
+            <div className={itemPrice}>
+              {(item.salePrice ?? item.price).toLocaleString()}원
+              {item.quantity > 1 && (
+                <span className={itemQuantity}>{item.quantity}개</span>
+              )}
+            </div>
+          </div>
+        </Link>
+      ))}
+
+      <div className={cardFooter}>
+        <span className={totalAmount}>
+          총 {order.totalAmount.toLocaleString()}원
+        </span>
+      </div>
+    </article>
+  );
+}

--- a/musinsa-coding/frontend/src/components/my/ReviewCard.css.ts
+++ b/musinsa-coding/frontend/src/components/my/ReviewCard.css.ts
@@ -1,0 +1,98 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const reviewCard = style({
+  backgroundColor: vars.color.white,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  padding: vars.space.md,
+});
+
+export const productRow = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space.sm,
+  marginBottom: vars.space.md,
+  paddingBottom: vars.space.md,
+  borderBottom: `1px solid ${vars.color.gray100}`,
+});
+
+export const productThumb = style({
+  width: "48px",
+  height: "48px",
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.gray200,
+  objectFit: "cover",
+  flexShrink: 0,
+});
+
+export const productInfo = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const productBrand = style({
+  fontSize: "11px",
+  color: vars.color.textTertiary,
+});
+
+export const productName = style({
+  fontSize: "13px",
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+export const starRow = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "2px",
+  marginBottom: vars.space.sm,
+});
+
+export const star = style({
+  width: "14px",
+  height: "14px",
+});
+
+export const starFilled = style({
+  color: "#FFC107",
+});
+
+export const starEmpty = style({
+  color: vars.color.gray300,
+});
+
+export const reviewContent = style({
+  fontSize: "14px",
+  color: vars.color.textPrimary,
+  lineHeight: 1.6,
+  marginBottom: vars.space.sm,
+});
+
+export const reviewDate = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+});
+
+export const reviewActions = style({
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: vars.space.sm,
+  marginTop: vars.space.sm,
+});
+
+export const actionButton = style({
+  fontSize: "13px",
+  color: vars.color.textTertiary,
+  cursor: "pointer",
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderRadius: vars.radius.sm,
+  transition: "all 0.15s",
+  ":hover": {
+    color: vars.color.textPrimary,
+    backgroundColor: vars.color.gray100,
+  },
+});

--- a/musinsa-coding/frontend/src/components/my/ReviewCard.tsx
+++ b/musinsa-coding/frontend/src/components/my/ReviewCard.tsx
@@ -1,0 +1,71 @@
+import type { UserReview } from "@/types";
+import {
+  reviewCard,
+  productRow,
+  productThumb,
+  productInfo,
+  productBrand,
+  productName,
+  starRow,
+  star,
+  starFilled,
+  starEmpty,
+  reviewContent,
+  reviewDate,
+  reviewActions,
+  actionButton,
+} from "./ReviewCard.css";
+
+interface Props {
+  review: UserReview;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function ReviewCard({ review }: Props) {
+  return (
+    <article className={reviewCard}>
+      <div className={productRow}>
+        <img
+          className={productThumb}
+          src={review.productThumbnail}
+          alt={review.productName}
+        />
+        <div className={productInfo}>
+          <div className={productBrand}>{review.productBrand}</div>
+          <div className={productName}>{review.productName}</div>
+        </div>
+      </div>
+
+      <div className={starRow}>
+        {[1, 2, 3, 4, 5].map((n) => (
+          <svg
+            key={n}
+            className={`${star} ${n <= review.rating ? starFilled : starEmpty}`}
+            viewBox="0 0 24 24"
+            fill={n <= review.rating ? "currentColor" : "none"}
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26" />
+          </svg>
+        ))}
+      </div>
+
+      <p className={reviewContent}>{review.content}</p>
+      <div className={reviewDate}>{formatDate(review.createdAt)}</div>
+
+      <div className={reviewActions}>
+        <button type="button" className={actionButton}>
+          수정
+        </button>
+        <button type="button" className={actionButton}>
+          삭제
+        </button>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
Close #34

## 변경 내역
- **주문 목록** (`/my/orders`): 상태별 필터 탭 (전체/입금대기/결제완료/배송중/배송완료/취소) + `Suspense` 래핑
- **주문 상세** (`/my/orders/[id]`): 주문 상태 타임라인, 상품 목록, 결제 정보
- **리뷰 목록** (`/my/reviews`): 별점 표시, 리뷰 내용, 이미지 갤러리
- **재사용 컴포넌트**: OrderCard, ReviewCard + Vanilla Extract 스타일