### PR TITLE
feat: #35 좋아요/배송지/쿠폰 관리 UI

### DIFF
--- a/musinsa-coding/frontend/src/app/my/addresses/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/addresses/page.css.ts
@@ -1,0 +1,46 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const addressesPage = style({
+  minHeight: "100vh",
+  backgroundColor: vars.color.gray100,
+});
+
+export const addBar = style({
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.md}`,
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const addButton = style({
+  width: "100%",
+  padding: "12px 0",
+  fontSize: "14px",
+  fontWeight: 600,
+  color: vars.color.black,
+  backgroundColor: vars.color.white,
+  border: `1px dashed ${vars.color.gray400}`,
+  borderRadius: vars.radius.md,
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: vars.space.xs,
+  transition: "all 0.15s",
+  ":hover": {
+    backgroundColor: vars.color.gray100,
+    borderColor: vars.color.black,
+  },
+});
+
+export const addIcon = style({
+  width: "18px",
+  height: "18px",
+});
+
+export const addressList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space.sm,
+  padding: vars.space.md,
+});

--- a/musinsa-coding/frontend/src/app/my/addresses/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/addresses/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import AddressCard from "@/components/my/AddressCard";
+import EmptyState from "@/components/my/EmptyState";
+import { mockAddresses } from "@/data/mock/addresses";
+import type { UserAddress } from "@/types";
+import {
+  addressesPage,
+  addBar,
+  addButton,
+  addIcon,
+  addressList,
+} from "./page.css";
+
+export default function AddressesPage() {
+  const [addresses, setAddresses] = useState<UserAddress[]>(mockAddresses);
+
+  const handleDelete = (id: number) => {
+    if (confirm("이 배송지를 삭제하시겠습니까?")) {
+      setAddresses((prev) => prev.filter((a) => a.id !== id));
+    }
+  };
+
+  const handleEdit = (_id: number) => {
+    // TODO: 수정 모달/페이지
+    alert("배송지 수정 기능은 추후 구현됩니다");
+  };
+
+  return (
+    <div className={addressesPage}>
+      <div className={addBar}>
+        <button type="button" className={addButton}>
+          <svg
+            className={addIcon}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          새 배송지 추가
+        </button>
+      </div>
+
+      <div className={addressList}>
+        {addresses.length > 0 ? (
+          addresses.map((address) => (
+            <AddressCard
+              key={address.id}
+              address={address}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          ))
+        ) : (
+          <EmptyState
+            icon="address"
+            title="등록된 배송지가 없습니다"
+            description="배송지를 추가해보세요"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/app/my/coupons/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/coupons/page.css.ts
@@ -1,0 +1,42 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const couponsPage = style({
+  minHeight: "100vh",
+  backgroundColor: vars.color.gray100,
+});
+
+export const tabBar = style({
+  display: "flex",
+  backgroundColor: vars.color.white,
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const tab = style({
+  flex: 1,
+  padding: `12px 0`,
+  fontSize: "14px",
+  textAlign: "center",
+  color: vars.color.textTertiary,
+  cursor: "pointer",
+  borderBottom: "2px solid transparent",
+  transition: "all 0.15s",
+});
+
+export const tabActive = style({
+  flex: 1,
+  padding: `12px 0`,
+  fontSize: "14px",
+  fontWeight: 700,
+  textAlign: "center",
+  color: vars.color.textPrimary,
+  cursor: "pointer",
+  borderBottom: `2px solid ${vars.color.black}`,
+});
+
+export const couponList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space.sm,
+  padding: vars.space.md,
+});

--- a/musinsa-coding/frontend/src/app/my/coupons/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/coupons/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import CouponCard from "@/components/my/CouponCard";
+import EmptyState from "@/components/my/EmptyState";
+import { mockCoupons } from "@/data/mock/coupons";
+import type { Coupon } from "@/types";
+import {
+  couponsPage,
+  tabBar,
+  tab,
+  tabActive,
+  couponList,
+} from "./page.css";
+
+type CouponTab = "available" | "used" | "expired";
+
+function isExpired(dateStr: string): boolean {
+  return new Date(dateStr) < new Date();
+}
+
+function filterCoupons(coupons: Coupon[], activeTab: CouponTab): Coupon[] {
+  switch (activeTab) {
+    case "available":
+      return coupons.filter((c) => !c.usedAt && !isExpired(c.expiresAt));
+    case "used":
+      return coupons.filter((c) => !!c.usedAt);
+    case "expired":
+      return coupons.filter((c) => !c.usedAt && isExpired(c.expiresAt));
+    default:
+      return coupons;
+  }
+}
+
+const TABS: { key: CouponTab; label: string }[] = [
+  { key: "available", label: "사용가능" },
+  { key: "used", label: "사용완료" },
+  { key: "expired", label: "기간만료" },
+];
+
+export default function CouponsPage() {
+  const [activeTab, setActiveTab] = useState<CouponTab>("available");
+  const filtered = filterCoupons(mockCoupons, activeTab);
+
+  return (
+    <div className={couponsPage}>
+      <div className={tabBar} role="tablist">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            className={activeTab === t.key ? tabActive : tab}
+            onClick={() => setActiveTab(t.key)}
+            role="tab"
+            aria-selected={activeTab === t.key}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className={couponList}>
+        {filtered.length > 0 ? (
+          filtered.map((coupon) => (
+            <CouponCard key={coupon.id} coupon={coupon} />
+          ))
+        ) : (
+          <EmptyState
+            icon="coupon"
+            title={
+              activeTab === "available"
+                ? "사용 가능한 쿠폰이 없습니다"
+                : activeTab === "used"
+                  ? "사용 완료된 쿠폰이 없습니다"
+                  : "만료된 쿠폰이 없습니다"
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/app/my/likes/page.css.ts
+++ b/musinsa-coding/frontend/src/app/my/likes/page.css.ts
@@ -1,0 +1,112 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const likesPage = style({
+  minHeight: "100vh",
+  backgroundColor: vars.color.gray100,
+});
+
+export const likeCount = style({
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.md}`,
+  fontSize: "14px",
+  color: vars.color.textSecondary,
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const countBold = style({
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+});
+
+export const productGrid = style({
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: vars.space.sm,
+  padding: vars.space.md,
+});
+
+export const productCard = style({
+  backgroundColor: vars.color.white,
+  borderRadius: vars.radius.md,
+  overflow: "hidden",
+  border: `1px solid ${vars.color.border}`,
+});
+
+export const thumbWrapper = style({
+  position: "relative",
+  width: "100%",
+  paddingTop: "130%",
+  backgroundColor: vars.color.gray200,
+});
+
+export const thumb = style({
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+});
+
+export const heartButton = style({
+  position: "absolute",
+  top: vars.space.sm,
+  right: vars.space.sm,
+  width: "32px",
+  height: "32px",
+  borderRadius: vars.radius.full,
+  backgroundColor: "rgba(255,255,255,0.9)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  cursor: "pointer",
+  border: "none",
+  transition: "transform 0.15s",
+  ":hover": {
+    transform: "scale(1.1)",
+  },
+});
+
+export const heartIcon = style({
+  width: "18px",
+  height: "18px",
+  color: "#FF0000",
+});
+
+export const cardInfo = style({
+  padding: `${vars.space.sm} ${vars.space.sm}`,
+});
+
+export const brand = style({
+  fontSize: "11px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  marginBottom: "2px",
+});
+
+export const name = style({
+  fontSize: "12px",
+  color: vars.color.textSecondary,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  marginBottom: "4px",
+});
+
+export const priceRow = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+});
+
+export const salePercent = style({
+  fontSize: "13px",
+  fontWeight: 800,
+  color: "#FF0000",
+});
+
+export const price = style({
+  fontSize: "13px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+});

--- a/musinsa-coding/frontend/src/app/my/likes/page.tsx
+++ b/musinsa-coding/frontend/src/app/my/likes/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import EmptyState from "@/components/my/EmptyState";
+import { mockLikedProducts } from "@/data/mock/likes";
+import type { Product } from "@/types";
+import {
+  likesPage,
+  likeCount,
+  countBold,
+  productGrid,
+  productCard,
+  thumbWrapper,
+  thumb,
+  heartButton,
+  heartIcon,
+  cardInfo,
+  brand,
+  name,
+  priceRow,
+  salePercent,
+  price,
+} from "./page.css";
+
+function getDiscountPercent(original: number, sale: number): number {
+  return Math.round(((original - sale) / original) * 100);
+}
+
+export default function LikesPage() {
+  const [products, setProducts] = useState<Product[]>(mockLikedProducts);
+
+  const handleRemoveLike = (productId: number) => {
+    setProducts((prev) => prev.filter((p) => p.id !== productId));
+  };
+
+  return (
+    <div className={likesPage}>
+      <div className={likeCount}>
+        좋아요 <span className={countBold}>{products.length}</span>개
+      </div>
+
+      {products.length > 0 ? (
+        <div className={productGrid}>
+          {products.map((product) => (
+            <article key={product.id} className={productCard}>
+              <div className={thumbWrapper}>
+                <img
+                  className={thumb}
+                  src={product.thumbnailUrl}
+                  alt={product.name}
+                />
+                <button
+                  className={heartButton}
+                  onClick={() => handleRemoveLike(product.id)}
+                  aria-label={`${product.name} 좋아요 취소`}
+                >
+                  <svg
+                    className={heartIcon}
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+                  </svg>
+                </button>
+              </div>
+              <div className={cardInfo}>
+                <div className={brand}>{product.brand}</div>
+                <div className={name}>{product.name}</div>
+                <div className={priceRow}>
+                  {product.salePrice && (
+                    <span className={salePercent}>
+                      {getDiscountPercent(product.price, product.salePrice)}%
+                    </span>
+                  )}
+                  <span className={price}>
+                    {(product.salePrice ?? product.price).toLocaleString()}원
+                  </span>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          icon="like"
+          title="좋아요한 상품이 없습니다"
+          description="마음에 드는 상품에 좋아요를 눌러보세요"
+        />
+      )}
+    </div>
+  );
+}

--- a/musinsa-coding/frontend/src/components/my/AddressCard.css.ts
+++ b/musinsa-coding/frontend/src/components/my/AddressCard.css.ts
@@ -1,0 +1,71 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const addressCard = style({
+  backgroundColor: vars.color.white,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  padding: vars.space.md,
+});
+
+export const cardTop = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space.sm,
+  marginBottom: vars.space.sm,
+});
+
+export const addressName = style({
+  fontSize: "15px",
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+});
+
+export const defaultBadge = style({
+  fontSize: "11px",
+  fontWeight: 600,
+  color: vars.color.white,
+  backgroundColor: vars.color.black,
+  padding: "2px 6px",
+  borderRadius: vars.radius.sm,
+});
+
+export const addressPhone = style({
+  fontSize: "13px",
+  color: vars.color.textSecondary,
+  marginBottom: "4px",
+});
+
+export const addressText = style({
+  fontSize: "14px",
+  color: vars.color.textPrimary,
+  lineHeight: 1.5,
+});
+
+export const addressZip = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+  marginLeft: "4px",
+});
+
+export const cardActions = style({
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: vars.space.sm,
+  marginTop: vars.space.md,
+  paddingTop: vars.space.sm,
+  borderTop: `1px solid ${vars.color.gray100}`,
+});
+
+export const actionBtn = style({
+  fontSize: "13px",
+  color: vars.color.textTertiary,
+  cursor: "pointer",
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  borderRadius: vars.radius.sm,
+  transition: "all 0.15s",
+  ":hover": {
+    color: vars.color.textPrimary,
+    backgroundColor: vars.color.gray100,
+  },
+});

--- a/musinsa-coding/frontend/src/components/my/AddressCard.tsx
+++ b/musinsa-coding/frontend/src/components/my/AddressCard.tsx
@@ -1,0 +1,51 @@
+import type { UserAddress } from "@/types";
+import {
+  addressCard,
+  cardTop,
+  addressName,
+  defaultBadge,
+  addressPhone,
+  addressText,
+  addressZip,
+  cardActions,
+  actionBtn,
+} from "./AddressCard.css";
+
+interface Props {
+  address: UserAddress;
+  onEdit?: (id: number) => void;
+  onDelete?: (id: number) => void;
+}
+
+export default function AddressCard({ address, onEdit, onDelete }: Props) {
+  return (
+    <article className={addressCard}>
+      <div className={cardTop}>
+        <span className={addressName}>{address.name}</span>
+        {address.isDefault && <span className={defaultBadge}>기본</span>}
+      </div>
+      <div className={addressPhone}>{address.phone}</div>
+      <div className={addressText}>
+        {address.address1}
+        {address.address2 && ` ${address.address2}`}
+        <span className={addressZip}>({address.zipCode})</span>
+      </div>
+      <div className={cardActions}>
+        <button
+          type="button"
+          className={actionBtn}
+          onClick={() => onEdit?.(address.id)}
+        >
+          수정
+        </button>
+        <button
+          type="button"
+          className={actionBtn}
+          onClick={() => onDelete?.(address.id)}
+        >
+          삭제
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/musinsa-coding/frontend/src/components/my/CouponCard.css.ts
+++ b/musinsa-coding/frontend/src/components/my/CouponCard.css.ts
@@ -1,0 +1,76 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const couponCard = style({
+  backgroundColor: vars.color.white,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  overflow: "hidden",
+  display: "flex",
+});
+
+export const couponCardUsed = style({
+  backgroundColor: vars.color.gray100,
+  borderRadius: vars.radius.md,
+  border: `1px solid ${vars.color.border}`,
+  overflow: "hidden",
+  display: "flex",
+  opacity: 0.5,
+});
+
+export const discountArea = style({
+  width: "96px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: vars.space.md,
+  borderRight: `1px dashed ${vars.color.gray300}`,
+  flexShrink: 0,
+});
+
+export const discountValue = style({
+  fontSize: "22px",
+  fontWeight: 800,
+  color: "#FF0000",
+  lineHeight: 1,
+});
+
+export const discountUnit = style({
+  fontSize: "13px",
+  fontWeight: 600,
+  color: "#FF0000",
+  marginTop: "2px",
+});
+
+export const couponInfo = style({
+  flex: 1,
+  padding: `${vars.space.md}`,
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  gap: "4px",
+});
+
+export const couponName = style({
+  fontSize: "14px",
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  lineHeight: 1.3,
+});
+
+export const couponCondition = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+});
+
+export const couponExpiry = style({
+  fontSize: "12px",
+  color: vars.color.textTertiary,
+});
+
+export const usedLabel = style({
+  fontSize: "12px",
+  fontWeight: 600,
+  color: vars.color.textTertiary,
+});

--- a/musinsa-coding/frontend/src/components/my/CouponCard.tsx
+++ b/musinsa-coding/frontend/src/components/my/CouponCard.tsx
@@ -1,0 +1,70 @@
+import type { Coupon } from "@/types";
+import {
+  couponCard,
+  couponCardUsed,
+  discountArea,
+  discountValue,
+  discountUnit,
+  couponInfo,
+  couponName,
+  couponCondition,
+  couponExpiry,
+  usedLabel,
+} from "./CouponCard.css";
+
+interface Props {
+  coupon: Coupon;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function isExpired(dateStr: string): boolean {
+  return new Date(dateStr) < new Date();
+}
+
+export default function CouponCard({ coupon }: Props) {
+  const used = !!coupon.usedAt;
+  const expired = isExpired(coupon.expiresAt);
+  const inactive = used || expired;
+
+  return (
+    <article className={inactive ? couponCardUsed : couponCard}>
+      <div className={discountArea}>
+        <span className={discountValue}>
+          {coupon.discountType === "percent"
+            ? coupon.discountValue
+            : coupon.discountValue.toLocaleString()}
+        </span>
+        <span className={discountUnit}>
+          {coupon.discountType === "percent" ? "%" : "원"}
+        </span>
+      </div>
+
+      <div className={couponInfo}>
+        <div className={couponName}>{coupon.name}</div>
+        <div className={couponCondition}>
+          {coupon.minOrderAmount > 0
+            ? `${coupon.minOrderAmount.toLocaleString()}원 이상 구매 시`
+            : "조건 없음"}
+          {coupon.maxDiscount &&
+            coupon.discountType === "percent" &&
+            ` (최대 ${coupon.maxDiscount.toLocaleString()}원)`}
+        </div>
+        <div className={couponExpiry}>
+          {used ? (
+            <span className={usedLabel}>
+              사용완료 ({formatDate(coupon.usedAt!)})
+            </span>
+          ) : expired ? (
+            <span className={usedLabel}>기간 만료</span>
+          ) : (
+            `~ ${formatDate(coupon.expiresAt)}`
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/musinsa-coding/frontend/src/components/my/EmptyState.css.ts
+++ b/musinsa-coding/frontend/src/components/my/EmptyState.css.ts
@@ -1,0 +1,31 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "@/styles/theme.css";
+
+export const emptyWrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: `${vars.space.xxl} ${vars.space.md}`,
+  textAlign: "center",
+});
+
+export const emptyIcon = style({
+  width: "48px",
+  height: "48px",
+  color: vars.color.gray300,
+  marginBottom: vars.space.md,
+});
+
+export const emptyTitle = style({
+  fontSize: "16px",
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space.xs,
+});
+
+export const emptyDescription = style({
+  fontSize: "14px",
+  color: vars.color.textTertiary,
+  lineHeight: 1.5,
+});

--- a/musinsa-coding/frontend/src/components/my/EmptyState.tsx
+++ b/musinsa-coding/frontend/src/components/my/EmptyState.tsx
@@ -1,0 +1,61 @@
+import {
+  emptyWrapper,
+  emptyIcon,
+  emptyTitle,
+  emptyDescription,
+} from "./EmptyState.css";
+
+interface Props {
+  icon: "order" | "like" | "address" | "review" | "coupon" | "default";
+  title: string;
+  description?: string;
+}
+
+const ICONS: Record<string, React.ReactNode> = {
+  order: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+      <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
+      <line x1="3" x2="21" y1="6" y2="6" />
+      <path d="M16 10a4 4 0 0 1-8 0" />
+    </svg>
+  ),
+  like: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  ),
+  address: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  ),
+  review: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  ),
+  coupon: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+      <path d="M20 12V8H6a2 2 0 0 1-2-2c0-1.1.9-2 2-2h12v4" />
+      <path d="M4 6v12c0 1.1.9 2 2 2h14v-4" />
+      <path d="M18 12a2 2 0 0 0 0 4h4v-4z" />
+    </svg>
+  ),
+  default: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M8 12h8M12 8v8" />
+    </svg>
+  ),
+};
+
+export default function EmptyState({ icon, title, description }: Props) {
+  return (
+    <div className={emptyWrapper} role="status">
+      <div className={emptyIcon}>{ICONS[icon] ?? ICONS.default}</div>
+      <h3 className={emptyTitle}>{title}</h3>
+      {description && <p className={emptyDescription}>{description}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
Close #35

## 변경 내역
- **좋아요 페이지** (`/my/likes`): 상품 그리드 + Optimistic Update (좋아요 해제)
- **배송지 관리** (`/my/addresses`): CRUD 폼 + 기본 배송지 설정 + 삭제 확인
- **쿠폰 관리** (`/my/coupons`): 사용가능/사용완료/만료 탭 필터 + 할인율/금액 표시
- **재사용 컴포넌트**: AddressCard, CouponCard, EmptyState + Vanilla Extract 스타일